### PR TITLE
Fixed Auto property synthesis warning in Xcode 6.3

### DIFF
--- a/CCNPreferencesWindowController/CCNPreferencesWindowController.m
+++ b/CCNPreferencesWindowController/CCNPreferencesWindowController.m
@@ -58,7 +58,6 @@ static unsigned short const CCNEscapeKey = 53;
 #pragma mark -
 
 @interface CCNPreferencesWindowController() <NSToolbarDelegate, NSWindowDelegate>
-@property (strong) CCNPreferencesWindow *window;
 
 @property (strong) NSToolbar *toolbar;
 @property (strong) NSSegmentedControl *segmentedControl;


### PR DESCRIPTION
`Auto property synthesis will not synthesize property 'window'; it will
be implemented by its superclass, use @dynamic to acknowledge intention`

window property is already present in superclass