### PR TITLE
wrap content view without vibrancy

### DIFF
--- a/CCNPreferencesWindowController/CCNPreferencesWindowController.m
+++ b/CCNPreferencesWindowController/CCNPreferencesWindowController.m
@@ -276,7 +276,9 @@ static unsigned short const CCNEscapeKey = 53;
         self.window.contentView = effectView;
     }
     else {
-        self.window.contentView = newContentView;
+        NSView *view = [[NSView alloc] initWithFrame:newContentView.frame];
+        [view addSubview:newContentView];
+        self.window.contentView = view;
     }
 
     __weak typeof(self) wSelf = self;


### PR DESCRIPTION
Without wrapping the `newContentView`, animations looked odd: the new content "fell down" from above, shining through the toolbar. With this setting, it fades in properly.