### PR TITLE
Show prefs window with custom activated segment

### DIFF
--- a/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
+++ b/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
@@ -179,7 +179,10 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
     ///
     ///  Show the preferences window.
     ///
-    func showPreferencesWindow() {
+    /// - parameter selectViewController: Segment to show initially. Defaults to `nil`, 
+    ///   which shows the first one.
+    ///
+    func showPreferencesWindow(selectViewController selectedViewController: CCNPreferencesWindowControllerProtocol? = nil) {
         
         if window!.isVisible {
             return
@@ -202,7 +205,9 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
         }
         
         if activeViewController == nil {
-            activateViewController(viewControllers[0], animate:false)
+            let viewController = selectedViewController ?? viewControllers[0]
+            toolbar?.selectedItemIdentifier = type(of: viewController).preferencesIdentifier
+            activateViewController(viewController, animate: false)
             window?.center()
         }
         
@@ -367,14 +372,9 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
     
     fileprivate func viewControllerWithIdentifier(_ identifier: String) -> CCNPreferencesWindowControllerProtocol? {
 
-        for viewController in viewControllers {
-            if type(of: viewController).preferencesIdentifier == identifier {
-                return viewController
-            }
-        }
-        
-        return nil
-        
+        return viewControllers
+            .filter({ type(of: $0).preferencesIdentifier == identifier })
+            .first
     }
     
     // MARK: Toolbar Delegate Protocol
@@ -470,12 +470,12 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
     
     func toolbarItemAction(_ toolbarItem: NSToolbarItem) {
         
-        if let activeViewController = activeViewController,
+        guard let activeViewController = activeViewController,
             type(of: activeViewController).preferencesIdentifier != toolbarItem.itemIdentifier,
-            let viewController = viewControllerWithIdentifier(toolbarItem.itemIdentifier) {
+            let viewController = viewControllerWithIdentifier(toolbarItem.itemIdentifier)
+            else { return }
 
-            activateViewController(viewController, animate: true)
-        }
+        activateViewController(viewController, animate: true)
         
     }
     

--- a/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
+++ b/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
@@ -211,15 +211,21 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
             
         }
 
-        if let viewController = selectedViewController {
-            activateViewController(viewController, animate: false)
-            window?.center()
-        } else if activeViewController == nil {
-            let viewController = viewControllers[0]
-            activateViewController(viewController, animate: false)
-            window?.center()
-        }
-        
+        let initialViewController: CCNPreferencesWindowControllerProtocol = {
+
+            if let selectedViewController = selectedViewController {
+                return selectedViewController
+            }
+
+            if let activeViewController = activeViewController {
+                return activeViewController
+            }
+
+            return viewControllers[0]
+        }()
+
+        activateViewController(initialViewController, animate: false)
+        window?.center()
         window?.alphaValue = 1.0
         
     }

--- a/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
+++ b/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
@@ -175,7 +175,14 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
     ////////////////////////////////////////////////////////////////////////////////
     
     // MARK: Show & Hide Preferences Window
-    
+
+    func showPreferencesWindow<T : CCNPreferencesWindowControllerProtocol>(selectedPreferencesOfType preferencesType: T.Type) {
+
+        let viewController = viewControllerWithIdentifier(preferencesType.preferencesIdentifier)
+        showPreferencesWindow(selectViewController: viewController)
+
+    }
+
     ///
     ///  Show the preferences window.
     ///

--- a/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
+++ b/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
@@ -191,23 +191,25 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
     ///
     func showPreferencesWindow(selectViewController selectedViewController: CCNPreferencesWindowControllerProtocol? = nil) {
         
-        if window!.isVisible {
-            window?.makeKeyAndOrderFront(self)
+        guard let window = window else { preconditionFailure("window not set up") }
+
+        if window.isVisible {
+            showWindow(self)
             return
         }
-        
-        window?.alphaValue = 0.0
+
+        window.alphaValue = 0.0
         showWindow(self)
-        window?.makeKeyAndOrderFront(self)
+        window.makeKeyAndOrderFront(self)
         NSApplication.shared().activate(ignoringOtherApps: true)
         
-        if window?.toolbar != nil {
+        if let toolbar = window.toolbar {
             
             if showToolbarItemsAsSegmentedControl {
                 segmentedControl?.selectSegment(withTag: 0)
             } else if let toolbarDefaultItemIdentifiers = self.toolbarDefaultItemIdentifiers,
                 toolbarDefaultItemIdentifiers.count > 0 {
-                window?.toolbar!.selectedItemIdentifier = toolbarDefaultItemIdentifiers[(centerToolbarItems ? 1 : 0)]
+                toolbar.selectedItemIdentifier = toolbarDefaultItemIdentifiers[(centerToolbarItems ? 1 : 0)]
             }
             
         }
@@ -226,8 +228,8 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
         }()
 
         activateViewController(initialViewController, animate: false)
-        window?.center()
-        window?.alphaValue = 1.0
+        window.center()
+        window.alphaValue = 1.0
         
     }
 

--- a/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
+++ b/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
@@ -210,10 +210,12 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
             }
             
         }
-        
-        if activeViewController == nil {
-            let viewController = selectedViewController ?? viewControllers[0]
-            toolbar?.selectedItemIdentifier = type(of: viewController).preferencesIdentifier
+
+        if let viewController = selectedViewController {
+            activateViewController(viewController, animate: false)
+            window?.center()
+        } else if activeViewController == nil {
+            let viewController = viewControllers[0]
             activateViewController(viewController, animate: false)
             window?.center()
         }
@@ -221,7 +223,8 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
         window?.alphaValue = 1.0
         
     }
-    
+
+
     ///
     ///  Hide the preferences window.
     ///
@@ -327,6 +330,8 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
         
         guard let preferencesViewController = viewController as? NSViewController,
             let window = self.window else { return }
+
+        toolbar?.selectedItemIdentifier = type(of: viewController).preferencesIdentifier
 
         let currentWindowFrame = window.frame
         let frameRectForContentRect = window.frameRect(forContentRect: preferencesViewController.view.frame)

--- a/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
+++ b/CCNPreferencesWindowController/Swift/CCNPreferencesWindowController.swift
@@ -192,6 +192,7 @@ class CCNPreferencesWindowController : NSWindowController, NSToolbarDelegate, NS
     func showPreferencesWindow(selectViewController selectedViewController: CCNPreferencesWindowControllerProtocol? = nil) {
         
         if window!.isVisible {
+            window?.makeKeyAndOrderFront(self)
             return
         }
         

--- a/CCNPreferencesWindowController/Swift/CCNPreferencesWindowControllerProtocol.swift
+++ b/CCNPreferencesWindowController/Swift/CCNPreferencesWindowControllerProtocol.swift
@@ -35,13 +35,13 @@ import AppKit
 @objc protocol CCNPreferencesWindowControllerProtocol {
     
     /// The identifier of the preference panel.
-    func preferencesIdentifier() -> String
+    static var preferencesIdentifier: String { get }
     
     /// The title of the preference panel.
-    func preferencesTitle() -> String
+    static var preferencesTitle: String { get }
     
     /// The icon of the preference panel.
-    func preferencesIcon() -> NSImage
+    static var preferencesIcon: NSImage { get }
     
     /// The preference panel's first responder
     @objc optional func firstResponder() -> NSResponder

--- a/Swift-Example/PreferencesControllerTest-Swift.xcodeproj/project.pbxproj
+++ b/Swift-Example/PreferencesControllerTest-Swift.xcodeproj/project.pbxproj
@@ -27,7 +27,6 @@
 		DFBDEA7F1C63CEAB00FA47BF /* AdvancedPreferencesController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdvancedPreferencesController.swift; path = Panels/AdvancedPreferencesController.swift; sourceTree = "<group>"; };
 		DFBDEA801C63CEAB00FA47BF /* AdvancedPreferencesController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = AdvancedPreferencesController.xib; path = Panels/AdvancedPreferencesController.xib; sourceTree = "<group>"; };
 		FDADE0D71CAB02DF003394C5 /* CCNPreferencesWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CCNPreferencesWindowController.swift; path = Swift/CCNPreferencesWindowController.swift; sourceTree = "<group>"; };
-		FDADE0D81CAB02DF003394C5 /* CCNPreferencesWindowControllerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CCNPreferencesWindowControllerProtocol.h; path = ObjC/CCNPreferencesWindowControllerProtocol.h; sourceTree = "<group>"; };
 		FDADE0D91CAB02DF003394C5 /* CCNPreferencesWindowControllerProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CCNPreferencesWindowControllerProtocol.swift; path = Swift/CCNPreferencesWindowControllerProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -94,7 +93,6 @@
 			isa = PBXGroup;
 			children = (
 				FDADE0D71CAB02DF003394C5 /* CCNPreferencesWindowController.swift */,
-				FDADE0D81CAB02DF003394C5 /* CCNPreferencesWindowControllerProtocol.h */,
 				FDADE0D91CAB02DF003394C5 /* CCNPreferencesWindowControllerProtocol.swift */,
 			);
 			name = CCNPreferencesWindowController;

--- a/Swift-Example/PreferencesControllerTest/Panels/AdvancedPreferencesController.swift
+++ b/Swift-Example/PreferencesControllerTest/Panels/AdvancedPreferencesController.swift
@@ -30,19 +30,19 @@ class AdvancedPreferencesController: NSViewController, CCNPreferencesWindowContr
     
     // MARK: - Preferences Panel Protocol
     
-    func preferencesIcon() -> NSImage {
-        
+    static var preferencesIcon: NSImage {
+
         return NSImage(named: NSImageNameAdvanced)!
         
     }
     
-    func preferencesIdentifier() -> String {
+    static var preferencesIdentifier: String {
         
         return "Advanced"
         
     }
     
-    func preferencesTitle() -> String {
+    static var preferencesTitle: String {
         
         return "Advanced"
         

--- a/Swift-Example/PreferencesControllerTest/Panels/GeneralPreferencesController.swift
+++ b/Swift-Example/PreferencesControllerTest/Panels/GeneralPreferencesController.swift
@@ -32,19 +32,19 @@ class GeneralPreferencesController: NSViewController, CCNPreferencesWindowContro
     
     // MARK: - Preferences Panel Protocol
     
-    func preferencesIcon() -> NSImage {
+    static var preferencesIcon: NSImage {
         
         return NSImage(named: NSImageNamePreferencesGeneral)!
         
     }
     
-    func preferencesIdentifier() -> String {
+    static var preferencesIdentifier: String {
         
         return "General"
         
     }
     
-    func preferencesTitle() -> String {
+    static var preferencesTitle: String {
         
         return "General"
         


### PR DESCRIPTION
You can now optionally pass in a `CCNPreferencesWindowControllerProtocol` instance to make that the active pane when showing the window.

I also moved the preferences settings from instance functions to static (type) properties. This enables users to not keep an instance of the segment around they want to activate but instead pass in a concrete type that conforms to `CCNPreferencesWindowControllerProtocol`.
