### PR TITLE
Modify deprecated style mask names to current style mask names.

### DIFF
--- a/CCNPreferencesWindowController/CCNPreferencesWindowController.m
+++ b/CCNPreferencesWindowController/CCNPreferencesWindowController.m
@@ -407,7 +407,7 @@ static unsigned short const CCNEscapeKey = 53;
 
 - (instancetype)init {
     self = [super initWithContentRect:CCNPreferencesDefaultWindowRect
-                            styleMask:(NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSUnifiedTitleAndToolbarWindowMask)
+							styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskUnifiedTitleAndToolbar)
                               backing:NSBackingStoreBuffered
                                 defer:YES];
     if (self) {


### PR DESCRIPTION
Hi thanks to great library.
but my environment warnings style mask name is deprecated and now fixed to current style mask name.
So sorry indent was wrong.